### PR TITLE
return null rather than empty string when the query does not contain …

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -50,7 +50,7 @@ module.exports = {
         s = self.apos.launder.string(s);
 
         if (!s.match(/^\d\d\d\d$/)) {
-          return '';
+          return null;
         }
 
         return s;
@@ -84,7 +84,7 @@ module.exports = {
         s = self.apos.launder.string(s);
 
         if (!s.match(/^\d\d\d\d\-\d\d$/)) {
-          return '';
+          return null;
         }
 
         return s;
@@ -115,14 +115,18 @@ module.exports = {
         });
       },
       launder: function(s) {
-        return self.apos.launder.string(s);
+        s = self.apos.launder.string(s);
+        if (!s.match(/^\d\d\d\d\-\d\d\-\d\d$/)) {
+          return null;
+        }
+        return s;
       },
       choices: function(callback) {
         return self.toDistinct('publishedAt', function(err, results) {
           if (err) {
             return callback(err);
           }
-
+          results.sort();
           return callback(null, results);
         });
       }


### PR DESCRIPTION
…valid data. so the filter correctly declines to apply itself. Validate full dates. Sort full dates.